### PR TITLE
Add an option to hide the progress bar while still showing other output

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,12 @@ yanked along with a list of the yanked dependencies and the reason for the yank.
   in the cache.
 - `--refresh` - Refesh the entire cache and exit, no not check for yanked
   packages.
+- `--no-progress` - Don't show the progress bar when checking for yanked
+  packages, useful for CI/CD environments.
 - `--quiet` - Don't show any output, just return a non-zero exit code if any
   dependencies are yanked.
 - `--verbose` - Show more detailed output, including each dependency and it's
-  yank status.
+  yank status. This disables the progress bar.
 
 ### Configuration
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,6 @@
   "3h",etc
 - if `poetry.lock` is missing, catch the error and suggest running `poetry
   install` to create it
-- add option to just hide the progress bar
 
 ## Taking this further
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -21,10 +21,12 @@ yanked along with a list of the yanked dependencies and the reason for the yank.
   in the cache.
 - `--refresh` - Refesh the entire cache and exit, no not check for yanked
   packages.
+- `--no-progress` - Don't show the progress bar when checking for yanked
+  packages, useful for CI/CD environments.
 - `--quiet` - Don't show any output, just return a non-zero exit code if any
   dependencies are yanked.
 - `--verbose` - Show more detailed output, including each dependency and it's
-  yank status.
+  yank status. This disables the progress bar.
 
 ## Configuration
 

--- a/poetry_plugin_check_yanked/command.py
+++ b/poetry_plugin_check_yanked/command.py
@@ -47,6 +47,7 @@ class CheckYankedCommand(Command):
             "without checking the lockfile",
             flag=True,
         ),
+        option("no-progress", None, "Do not display a progress bar", flag=True),
     ]
 
     def __init__(self) -> None:
@@ -108,7 +109,9 @@ class CheckYankedCommand(Command):
             "packages in poetry.lock"
         )
 
-        use_progress = not self.io.is_verbose()
+        use_progress = not self.io.is_verbose() and not self.option(
+            "no-progress"
+        )
 
         if use_progress:
             progress = self.progress_bar(len(lock_data["package"]))


### PR DESCRIPTION
Use the `--no-progress` option to hide the progress bar. This is useful for the GitHub action (and will become the default option) or other CI environments.