### PR TITLE
Catch missing `poetry.lock` file

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,8 +10,6 @@
 - add defined expiry periods for the config file = "1h","1d", "1w", "1m", etc.
   Make the suffix apply to the period as well so you can have "1h", "2h",
   "3h",etc
-- if `poetry.lock` is missing, catch the error and suggest running `poetry
-  install` to create it
 
 ## Taking this further
 

--- a/poetry_plugin_check_yanked/command.py
+++ b/poetry_plugin_check_yanked/command.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -101,8 +102,19 @@ class CheckYankedCommand(Command):
         Returns a list of tuples, where each tuple contains the name, version
         and reason. If no yanked packages are found, an empty list is returned.
         """
-        with lockfile_path.open() as file:
-            lock_data = rtoml.load(file)
+        try:
+            with lockfile_path.open() as file:
+                lock_data = rtoml.load(file)
+        except FileNotFoundError:
+            self.line_error(
+                "<fg=red>\npoetry.lock file not found. "
+                "If you have not already run 'poetry install' please do so "
+                "before running this command.</>\n"
+                "\nIf you <b>have</b> run 'poetry install' and still see this "
+                "error, please check that the file exists in the current "
+                "directory.\n"
+            )
+            sys.exit(2)
 
         self.info(
             f"\nChecking <fg=green>{len(lock_data['package'])}</> "


### PR DESCRIPTION
If the `poetry.lock` is missing, catch this and exit the plugin with some helpful text.